### PR TITLE
Change package name to match the original due to `go mod tidy` error:

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -25,7 +25,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/outcaste-io/ristretto/z"
+	"github.com/dgraph-io/ristretto/z"
 	"go.uber.org/atomic"
 )
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/outcaste-io/ristretto/z"
+	"github.com/dgraph-io/ristretto/z"
 	"github.com/stretchr/testify/require"
 )
 

--- a/contrib/demo/node.go
+++ b/contrib/demo/node.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/outcaste-io/ristretto/z"
+	"github.com/dgraph-io/ristretto/z"
 	"github.com/dustin/go-humanize"
 )
 

--- a/contrib/demo/node_allocator.go
+++ b/contrib/demo/node_allocator.go
@@ -5,12 +5,12 @@ package main
 import (
 	"unsafe"
 
-	"github.com/outcaste-io/ristretto/z"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 // Defined in node.go.
 func init() {
-	alloc = z.NewAllocator(10 << 20, "demo")
+	alloc = z.NewAllocator(10<<20, "demo")
 }
 
 func newNode(val int) *node {

--- a/contrib/demo/node_jemalloc.go
+++ b/contrib/demo/node_jemalloc.go
@@ -5,7 +5,7 @@ package main
 import (
 	"unsafe"
 
-	"github.com/outcaste-io/ristretto/z"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 func newNode(val int) *node {

--- a/contrib/memtest/main.go
+++ b/contrib/memtest/main.go
@@ -31,8 +31,8 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/dgraph-io/ristretto/z"
 	"github.com/dustin/go-humanize"
-	"github.com/outcaste-io/ristretto/z"
 )
 
 type S struct {

--- a/contrib/memtest/withjemalloc.go
+++ b/contrib/memtest/withjemalloc.go
@@ -5,7 +5,7 @@ package main
 import (
 	"os"
 
-	"github.com/outcaste-io/ristretto/z"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 func Calloc(size int) []byte { return z.Calloc(size, "memtest") }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/outcaste-io/ristretto
+module github.com/dgraph-io/ristretto
 
 go 1.12
 

--- a/metrics.go
+++ b/metrics.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/outcaste-io/ristretto/z"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 type metricType int

--- a/policy.go
+++ b/policy.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/outcaste-io/ristretto/z"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 const (

--- a/store_test.go
+++ b/store_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/outcaste-io/ristretto/z"
+	"github.com/dgraph-io/ristretto/z"
 	"github.com/stretchr/testify/require"
 )
 

--- a/stress_test.go
+++ b/stress_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/outcaste-io/ristretto/sim"
+	"github.com/dgraph-io/ristretto/sim"
 	"github.com/stretchr/testify/require"
 )
 

--- a/z/btree.go
+++ b/z/btree.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/outcaste-io/ristretto/z/simd"
+	"github.com/dgraph-io/ristretto/z/simd"
 )
 
 var (

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/outcaste-io/ristretto/z/simd"
+	"github.com/dgraph-io/ristretto/z/simd"
 	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
```
go: github.com/dgraph-io/ristretto@v0.1.0 (replaced by github.com/goflink/ristretto@v0.0.0-20220420003845-bd658a460d49): parsing go.mod:
	module declares its path as: github.com/outcaste-io/ristretto
	        but was required as: github.com/dgraph-io/ristretto
```

# Context

(fix) Fixed errors "flag redefined: v"

Two packages register ``"v"` flag (`flag.Int("v", 0, "log level")` etc):

- `github.com/google/martian`
- `github.com/golang/glog`

`martian` package is used by `github.com/google/go-replayers/httpreplay` in our integration tests.

`glog` package is used by updated version of `gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer`. `tracer` module depends on `github.com/dgraph-io/ristretto` which imports `glog`.
There are PRs to remove glog from ristretto:

- https://github.com/dgraph-io/ristretto/pull/292
- https://github.com/dgraph-io/ristretto/pull/293

but the repository is abandoned (https://github.com/dgraph-io/ristretto/pull/292#issuecomment-1047071423)

`ristretto` is developed now as `github.com/outcaste-io/ristretto`.

This change replaces `ristretto` from  `github.com/dgraph-io/ristretto` with one found in `github.com/outcaste-io/ristretto`.

Another problem is that `github.com/outcaste-io/ristretto` uses different package name, so the code needed to be copied to `hub-api` repo into `./replacements/outcaste-io/ristretto` folder

```
github.com/dgraph-io/ristretto => github.com/outcaste-io/ristretto v0.2.0 
```

gives

```
$ go mod tidy
go: github.com/outcaste-io/ristretto@v0.2.0 used for two different module paths (github.com/dgraph-io/ristretto and github.com/outcaste-io/ristretto)
```

This ended with forked `outcaste-io/ristretto` repo and package name being changed in `go.mod` to `github.com/dgraph-io/ristretto`. This allowed installation of all packages and conflicting flags are no more
